### PR TITLE
Add `Risk` Table and Relation to `Applications`

### DIFF
--- a/api/prisma/migrations/20250530004213_add_risk_model/migration.sql
+++ b/api/prisma/migrations/20250530004213_add_risk_model/migration.sql
@@ -1,0 +1,31 @@
+-- AlterTable
+ALTER TABLE "listings" ALTER COLUMN "afs_last_run_at" SET DEFAULT '1970-01-01 00:00:00-07'::timestamp with time zone,
+ALTER COLUMN "last_application_update_at" SET DEFAULT '1970-01-01 00:00:00-07'::timestamp with time zone,
+ALTER COLUMN "requested_changes_date" SET DEFAULT '1970-01-01 00:00:00-07'::timestamp with time zone;
+
+-- CreateTable
+CREATE TABLE "risk" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v4(),
+    "application_id" UUID NOT NULL,
+    "risk_probability" DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    "risk_prediction" BOOLEAN NOT NULL DEFAULT false,
+    "veteran" BOOLEAN NOT NULL DEFAULT false,
+    "income" DOUBLE PRECISION DEFAULT 0,
+    "disabled" BOOLEAN NOT NULL DEFAULT false,
+    "num_people" INTEGER DEFAULT 1,
+    "age" INTEGER,
+    "benefits" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "risk_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "risk_application_id_key" ON "risk"("application_id");
+
+-- CreateIndex
+CREATE INDEX "risk_application_id_idx" ON "risk"("application_id");
+
+-- AddForeignKey
+ALTER TABLE "risk" ADD CONSTRAINT "risk_application_id_fkey" FOREIGN KEY ("application_id") REFERENCES "applications"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -224,12 +224,34 @@ model Applications {
   preferredUnitTypes           UnitTypes[]
   householdMember              HouseholdMember[]
   applicationLotteryPositions  ApplicationLotteryPositions[]
+  risk Risk?
 
   @@unique([listingId, confirmationCode])
   @@index([listingId])
   @@index([userId])
   @@map("applications")
 }
+
+model Risk {
+  id              String       @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  applicationId   String       @unique @map("application_id") @db.Uuid
+  riskProbability Float        @default(0.0) @map("risk_probability")
+  riskPrediction  Boolean      @default(false) @map("risk_prediction")
+  veteran         Boolean      @default(false) 
+  income          Float?       @default(0) 
+  disabled        Boolean      @default(false) 
+  numPeople       Int?         @default(1) @map("num_people")
+  age             Int?         @map("age")
+  benefits        Boolean      @default(false) 
+  createdAt       DateTime     @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt       DateTime     @updatedAt @map("updated_at") @db.Timestamp(6)
+
+  application     Applications @relation(fields: [applicationId], references: [id], onDelete: Cascade)
+
+  @@index([applicationId])
+  @@map("risk")
+}
+
 
 // Note: [file_id, label] formerly max length 128
 model Assets {


### PR DESCRIPTION
## 🛠️ PR: Add `Risk` Table and Relation to `Applications`

### 📋 What’s Changed

* Added a new `Risk` model to track risk-related metadata for each application.
* Linked each `Risk` row to a unique `Application` via a 1:1 relation.
* Added appropriate Prisma field mappings, defaults, and indices for maintainability and performance.

---

### 🔧 Prisma Schema Changes (`schema.prisma`)

#### ✅ New `Risk` Model

```prisma
model Risk {
  id              String       @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
  applicationId   String       @unique @map("application_id") @db.Uuid
  riskProbability Float        @default(0.0) @map("risk_probability")
  riskPrediction  Boolean      @default(false) @map("risk_prediction")
  veteran         Boolean      @default(false) 
  income          Float?       @default(0) 
  disabled        Boolean      @default(false) 
  numPeople       Int?         @default(1) @map("num_people")
  age             Int?         @map("age")
  benefits        Boolean      @default(false) 
  createdAt       DateTime     @default(now()) @map("created_at") @db.Timestamp(6)
  updatedAt       DateTime     @updatedAt @map("updated_at") @db.Timestamp(6)

  application     Applications @relation(fields: [applicationId], references: [id], onDelete: Cascade)

  @@index([applicationId])
  @@map("risk")
}
```

#### 🧩 Update to `Applications` Model

Add this relation in the `Applications` model:

```prisma
  risk Risk?
```

---

### 🧪 How to Generate and Run the Migration Locally

```bash
npx prisma migrate dev --name add-risk-model
```

> 💡 This will generate a new SQL migration under `prisma/migrations` and apply it to your local database.

---

#### 🧩 Use Prisma to Inspect

```bash
npx prisma studio
```
![image](https://github.com/user-attachments/assets/4f216a87-ef2f-4736-a91a-75bd15e3c61f)

---

