### PR TITLE
Reset Prisma Migrations to Match Current Schema

### DIFF
--- a/api/prisma/migrations/20250611004831_npx_prisma_migrate_reset/migration.sql
+++ b/api/prisma/migrations/20250611004831_npx_prisma_migrate_reset/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "listings" ALTER COLUMN "afs_last_run_at" SET DEFAULT '1970-01-01 00:00:00-07'::timestamp with time zone,
+ALTER COLUMN "last_application_update_at" SET DEFAULT '1970-01-01 00:00:00-07'::timestamp with time zone,
+ALTER COLUMN "requested_changes_date" SET DEFAULT '1970-01-01 00:00:00-07'::timestamp with time zone;


### PR DESCRIPTION
# 📄 PR: Reset Prisma Migrations to Match Current Schema

## 🔧 Purpose

This PR resets the Prisma migration history to ensure the database schema is **fully aligned** with the existing `schema.prisma` file.

## 🗂️ What Was Done

* ❌ Removed all existing migration files from `prisma/migrations`
* ✅ Ran `prisma migrate reset` to drop the database and apply a fresh migration set
* ✅ Generated a new migration to accurately reflect the current Prisma schema
* ✅ Regenerated Prisma Client to ensure it matches the updated schema

---

## ⚙️ Commands to Run

```bash
# 1. Remove existing migrations folder (optional but recommended for a clean reset)
rm -rf prisma/migrations

# 2. Create a fresh migration from current schema
npx prisma migrate dev --name init-schema-reset

# 3. Reset the database (drops all data, applies fresh migration)
npx prisma migrate reset

# 4. (Optional) If you have seed data
# Follow the prompt to re-seed the database, or run:
npx prisma db seed

# 5. Generate Prisma Client
npx prisma generate
```

---

## ✅ How to Test

### Verify Schema Alignment

* Run:

```bash
npx prisma migrate dev
```

If no changes are detected, the schema and database are now in sync.

### Verify Database Tables

* Open your database viewer (e.g., pgAdmin, TablePlus, Prisma Studio)
* Run:

```bash
npx prisma studio
```

* Confirm that all tables, indexes, and relationships reflect your `schema.prisma`.

### Test Application Functionality

* Run your application and test all critical CRUD operations:

  * Can you create, read, update, and delete records as expected?
  * Are foreign key constraints working?
  * Is seeding successful?

---

## 🚨 Important Notes

* This process **will wipe all existing data.** Ensure you have backups if you need to keep anything.
* This PR is suitable for **development or staging environments.**
* For production databases, a careful migration sync (without reset) should be performed instead.

---

