### PR TITLE
feat(public): implemented semantic search widget

### DIFF
--- a/sites/public/src/components/shared/FloatingHouseIcon.module.scss
+++ b/sites/public/src/components/shared/FloatingHouseIcon.module.scss
@@ -1,0 +1,47 @@
+.floatingContainer {
+  position: fixed;
+  bottom: 4rem;
+  right: 2.5rem;
+  z-index: 1000;
+}
+
+.floatingButton {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  background-color: #0077b6;
+  border: none;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease-in-out;
+  z-index: 1001;
+
+  &:hover {
+    transform: scale(1.1);
+    background-color: #005f92;
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(0, 119, 182, 0.3);
+  }
+
+  &.active {
+    transform: scale(1.1);
+    background-color: #005f92;
+  }
+}
+
+.icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  color: white;
+  transition: transform 0.3s ease-in-out;
+}
+
+.active .icon {
+  transform: rotate(180deg);
+} 

--- a/sites/public/src/components/shared/FloatingHouseIcon.tsx
+++ b/sites/public/src/components/shared/FloatingHouseIcon.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import styles from './FloatingHouseIcon.module.scss';
+import SemanticSearchModal from './SemanticSearchModal';
+
+const FloatingHouseIcon = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleClick = () => {
+    setIsModalOpen(!isModalOpen);
+  };
+
+  return (
+    <div className={styles.floatingContainer}>
+      <button
+        className={`${styles.floatingButton} ${isModalOpen ? styles.active : ''}`}
+        onClick={handleClick}
+        aria-label="Open semantic search"
+      >
+        <svg
+          className={styles.icon}
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 12L5 10M5 10L12 3L19 10M5 10V20C5 20.5523 5.44772 21 6 21H9M19 10L21 12M19 10V20C19 20.5523 18.5523 21 18 21H15M9 21C9.55228 21 10 20.5523 10 20V16C10 15.4477 10.4477 15 11 15H13C13.5523 15 14 15.4477 14 16V20C14 20.5523 14.4477 21 15 21M9 21H15"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+      <SemanticSearchModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      />
+    </div>
+  );
+};
+
+export default FloatingHouseIcon; 

--- a/sites/public/src/components/shared/SemanticSearchModal.module.scss
+++ b/sites/public/src/components/shared/SemanticSearchModal.module.scss
@@ -1,0 +1,213 @@
+.modalOverlay {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 250px;
+  height: 150px;
+  z-index: 999;
+  transition: height 0.3s ease-out;
+
+  &.hasResults {
+    height: 350px;
+  }
+}
+
+.modal {
+  background-color: white;
+  border-radius: 8px;
+  padding: 0.75rem;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  animation: slideIn 0.3s ease-out;
+  box-sizing: border-box;
+  // overflow-y: auto;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.closeButton {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background: none;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s ease;
+  z-index: 1;
+
+  &:hover {
+    color: #333;
+  }
+}
+
+.closeIcon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.title {
+  margin: 0 0 0.75rem;
+  color: #333;
+  font-size: 1rem;
+  padding-right: 1.5rem;
+}
+
+.searchForm {
+  margin-bottom: 0.75rem;
+}
+
+.searchInputWrapper {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.searchInput {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  height: 2.5rem;
+
+  &:focus {
+    outline: none;
+    border-color: #0077b6;
+    box-shadow: 0 0 0 2px rgba(0, 119, 182, 0.2);
+  }
+}
+
+.searchButton {
+  padding: 0.5rem;
+  background-color: #0077b6;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease;
+  gap: 0.5rem;
+  height: 2.5rem;
+  width: 2.5rem;
+
+  &:hover:not(:disabled) {
+    background-color: #005f92;
+  }
+
+  &:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+  }
+}
+
+.searchIcon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.loading {
+  color: #666;
+  font-size: 0.75rem;
+  margin-left: 0.5rem;
+  display: inline-block;
+}
+
+.error {
+  color: #dc3545;
+  font-size: 0.65rem;
+  display: inline-block;
+  background-color: #f8d7da;
+  border-radius: 4px;
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow-y: auto;
+  flex: 1;
+  margin-top: 0.5rem;
+  padding-right: 0.25rem;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 2px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: #888;
+    border-radius: 2px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: #555;
+  }
+}
+
+.resultItem {
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  transition: border-color 0.2s ease;
+
+  &:hover {
+    border-color: #0077b6;
+  }
+}
+
+.providerLink {
+  color: #0077b6;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.875rem;
+  display: block;
+  margin-bottom: 0.25rem;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.address {
+  color: #666;
+  font-size: 0.75rem;
+  margin-bottom: 0.25rem;
+  font-style: italic;
+}
+
+.services {
+  color: #666;
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+} 

--- a/sites/public/src/components/shared/SemanticSearchModal.tsx
+++ b/sites/public/src/components/shared/SemanticSearchModal.tsx
@@ -1,0 +1,145 @@
+import React, { useState, useEffect } from 'react';
+import { semanticSearch } from '../../lib/services/semanticSearch';
+import styles from './SemanticSearchModal.module.scss';
+
+interface SearchResult {
+  provider: string;
+  services: string;
+}
+
+interface SemanticSearchModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const SemanticSearchModal: React.FC<SemanticSearchModalProps> = ({ isOpen, onClose }) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (results.length > 0) {
+      const modalElement = document.querySelector(`.${styles.results}`);
+      if (modalElement) {
+        modalElement.scrollTo({ top: 0, behavior: "auto"});
+      }
+    }
+  }, [results]);
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!query.trim()) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await semanticSearch(query);
+      setResults(response.results);
+    } catch (err) {
+      setError('Failed to perform search. Please try again.');
+      setResults([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getProviderInfo = (provider: string) => {
+    const firstParenIndex = provider.indexOf('(');
+    const lastParenIndex = provider.lastIndexOf('(');
+    console.log(">>>", provider)
+    const name = firstParenIndex !== -1
+      ? provider.slice(0, firstParenIndex).trim()
+      : provider;
+
+    const address = lastParenIndex !== -1
+      ? provider.slice(lastParenIndex + 1, provider.lastIndexOf(')')).trim()
+      : null;
+
+    return { name, address };
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className={`${styles.modalOverlay} ${results.length > 0 ? styles.hasResults : ''}`} onClick={(e) => e.stopPropagation()}>
+      <div className={styles.modal}>
+        <button className={styles.closeButton} onClick={onClose} aria-label="Close modal">
+          <svg 
+            className={styles.closeIcon}
+            viewBox="0 0 24 24" 
+            fill="none" 
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path 
+              d="M6 18L18 6M6 6L18 18" 
+              stroke="currentColor" 
+              strokeWidth="2" 
+              strokeLinecap="round" 
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+
+        <h2 className={styles.title}>Resource Lookup</h2>
+
+        <form onSubmit={handleSearch} className={styles.searchForm}>
+          <div className={styles.searchInputWrapper}>
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search services..."
+              className={styles.searchInput}
+            />
+            <button type="submit" className={styles.searchButton} disabled={isLoading}>
+              <svg 
+                className={styles.searchIcon}
+                viewBox="0 0 24 24" 
+                fill="none" 
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path 
+                  d="M21 21L15 15M17 10C17 13.866 13.866 17 10 17C6.13401 17 3 13.866 3 10C3 6.13401 6.13401 3 10 3C13.866 3 17 6.13401 17 10Z" 
+                  stroke="currentColor" 
+                  strokeWidth="2" 
+                  strokeLinecap="round" 
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.5rem' }}>
+            {isLoading && <span className={styles.loading}>Searching...</span>}
+            {error && <span className={styles.error}>{error}</span>}
+          </div>
+        </form>
+
+        {results.length > 0 && (
+          <div className={styles.results}>
+            {results.map((result, index) => {
+              const { name, address } = getProviderInfo(result.provider);
+              return (
+                <div key={index} className={styles.resultItem}>
+                  <a 
+                    href={`/listings?search=${encodeURIComponent(name)}`}
+                    className={styles.providerLink}
+                  >
+                    {name}
+                  </a>
+                  {address && (
+                    <div className={styles.address}>{address}</div>
+                  )}
+                  <p className={styles.services}>{result.services}</p>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SemanticSearchModal;

--- a/sites/public/src/layouts/application.tsx
+++ b/sites/public/src/layouts/application.tsx
@@ -11,6 +11,7 @@ import { HeaderLink, SiteHeader } from "../patterns/SiteHeader"
 import styles from "./application.module.scss"
 import { User } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { ToastProps } from "@bloom-housing/ui-seeds/src/blocks/Toast"
+import FloatingHouseIcon from "../components/shared/FloatingHouseIcon"
 
 const getInMaintenance = () => {
   let inMaintenance = false
@@ -234,6 +235,7 @@ const Layout = (props) => {
       </div>
 
       <CustomSiteFooter />
+      <FloatingHouseIcon />
     </div>
   )
 }

--- a/sites/public/src/lib/services/semanticSearch.ts
+++ b/sites/public/src/lib/services/semanticSearch.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+
+interface SearchResult {
+  provider: string;
+  services: string;
+}
+
+interface SearchResponse {
+  query: string;
+  results: SearchResult[];
+}
+
+export const semanticSearch = async (query: string): Promise<SearchResponse> => {
+  try {
+    const response = await axios.post('http://localhost:5001/search', {
+      query,
+      top_n: 5
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error performing semantic search:', error);
+    throw error;
+  }
+}; 


### PR DESCRIPTION
This PR addresses #82 

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR implements the initial version of the semantic search widget. The widget provides users with the ability to input search queries and receive semantically relevant results from the backend.

##Changes

- Created `FloatingHousingIcon` component (`sites/public/src/components/shared/FloatingHouseIcon.module.scss`)
- Created `FloatingHousingIcon` associated css file (`sites/public/src/components/shared/FloatingHouseIcon.module.scss`)
- Created `SemanticSearchModal` component (`sites/public/src/components/shared/SemanticSearchModal.tsx`)
- Created `SemanticSearchModal` associated css file (`sites/public/src/components/shared/SemanticSearchModal.module.scss`)
- Created `semanticSearch` to preform call to microservice (`sites/public/src/lib/services/semanticSearch.ts`)
- Modified `sites/public/src/layouts/application.tsx`
- Displayed returned results in a list
- Added basic styling and loading indicator

## How Can This Be Tested/Reviewed?

How to test
1️⃣ Navigate to the home page (widget if logged in or not).
2️⃣ Enter a query into the search input (e.g., food, housing, etc).
3️⃣ Verify that:
- The semantic search route is hit after input debounce.
- Relevant search results are returned to floating window and displayed.
- "Searching" indicator shows while fetching data.
4️⃣ Test edge cases (empty input, very long input, rapid typing).


## Review Process:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
